### PR TITLE
PhantomJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+#  we use node 0.12 here on purpose to assure backwars compatibility with older node versions
   - "0.12"
 before_script:
   - "export DISPLAY=:99.0"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
       noInfo: true
     },
     reporters: ['progress'],
-    browsers: ['Chrome', 'Firefox'],
+    browsers: ['Chrome', 'Firefox', 'PhantomJS'],
     plugins: [ "karma-*" ]
   })
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "./node_modules/.bin/mocha --compilers js:babel/register ./test/*Test.js ./test/**/*Test.js",
     "test-coverage": "COVERAGE=1 ./node_modules/.bin/babel-node ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha  -- ./test/*Test.js ./test/**/*Test.js",
     "test-browser": "./node_modules/.bin/karma start --single-run",
-    "test-ci": "npm run test && npm run test-browser -- --browsers \"Firefox\" && npm run build-esdoc && npm run test-coverage",
+    "test-ci": "npm run test && npm run test-browser -- --browsers \"Firefox,PhantomJS\" && npm run build-esdoc && npm run test-coverage",
     "build-esdoc": " ./node_modules/.bin/esdoc -c esdoc.json",
     "build-dist": "./node_modules/.bin/webpack --progress --colors --bail && DIST_MIN=1 ./node_modules/.bin/webpack --progress --colors --bail",
     "build-readme2html": "mkdir -p build && ./node_modules/.bin/marked -i README.md -o build/README.hml && ./node_modules/.bin/marked -i CheatSheet.md -o build/CheatSheet.hml "
@@ -36,12 +36,13 @@
     "karma-chai-plugins": "^0.6.0",
     "karma-chrome-launcher": "^0.2.1",
     "karma-firefox-launcher": "^0.1.6",
-    "karma-phantomjs-launcher": "^0.2.2",
     "karma-mocha": "^0.2.0",
+    "karma-phantomjs-launcher": "^0.2.2",
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",
     "marked": "^0.3.5",
     "mocha": "^2.3.3",
+    "phantomjs": "^1.9.19",
     "webpack": "^1.12.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "karma-chai-plugins": "^0.6.0",
     "karma-chrome-launcher": "^0.2.1",
     "karma-firefox-launcher": "^0.1.6",
+    "karma-phantomjs-launcher": "^0.2.2",
     "karma-mocha": "^0.2.0",
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",


### PR DESCRIPTION
Last part of the old big PR #2 

- add a note why we are using node 0.12 for the travis tests
- add PhantomJS and use it in `npm run test-ci` in addition to Firefox
i think it makes sense to test with different environments, since travis doesn't seem to provide Chrome as test environment, using PhantomJS as a webkit based solution is still a good idea IMHO