### PR TITLE
Simplify deployment for gh-pages

### DIFF
--- a/deploy-gh-pages.js
+++ b/deploy-gh-pages.js
@@ -1,0 +1,15 @@
+var ghpages = require('gh-pages');
+var path = require('path');
+
+ghpages.publish(path.join(__dirname, '.publish'), {
+  src: ['_includes/README.md', '_includes/CheatSheet.md'],
+  branch: 'gh-pages',
+  add: true, // otherwise all other files will be deleted
+  message: 'Auto-generated commit'
+}, function(err, res) {
+  if (err != null) {
+    console.log(err);
+  } else {
+    console.log('pushed gh-branch');
+  }
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-esdoc": " ./node_modules/.bin/esdoc -c esdoc.json",
     "build-dist-es5": "./node_modules/.bin/babel src -d build/es5",
     "build-dist": "./node_modules/.bin/webpack --progress --colors --bail && DIST_MIN=1 ./node_modules/.bin/webpack --progress --colors --bail",
-    "build-readme2html": "mkdir -p build && ./node_modules/.bin/marked -i README.md -o build/README.html && ./node_modules/.bin/markdown-toc -i CheatSheet.md  && ./node_modules/.bin/marked -i CheatSheet.md -o build/CheatSheet.html"
+    "gh-pages": "mkdir -p .publish/_includes && cp README.md CheatSheet.md .publish/_includes/. && cd .publish; node ../deploy-gh-pages.js; cd ..; rm -rf .publish"
   },
   "keywords": [
     "date",
@@ -34,6 +34,7 @@
     "chai": "^3.5.0",
     "coveralls": "^2.11.8",
     "esdoc": "^0.4.6",
+    "gh-pages": "0.11.0",
     "isparta": "^4.0.0",
     "karma": "^0.13.22",
     "karma-chai-plugins": "^0.7.0",
@@ -43,8 +44,6 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "markdown-toc": "^0.12.3",
-    "marked": "^0.3.5",
     "mocha": "^2.4.5",
     "phantomjs": "^2.1.3",
     "webpack": "^1.12.14"


### PR DESCRIPTION
This is one of two parts to simplify the deployment.

With this setup you only need to sync the two markdown files (readme and cheat-sheet) from the master branch. If you change them just run `npm run gh-pages`, that's it.